### PR TITLE
 The search doesn't find anything if use a non-English localization

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Search Plugin Changelog
 <p><b>1.7.4</b>TBC</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/12'>Issue #12</a>] - fix: keep order of fields equal to order of reported fields.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/19'>Issue #19</a>] - The search doesn't find anything if use a non-English localization</li>
 </ul>
 
 <p><b>1.7.3</b> -- September 25, 2019</p>

--- a/src/i18n/search_i18n.properties
+++ b/src/i18n/search_i18n.properties
@@ -34,6 +34,7 @@ advance.user.search.more_options=More Options
 advance.user.search.less_options=Less Options
 advance.user.search.users_found=Users Found
 advance.user.search.online=Online
+advance.user.search.jid=Jabber ID
 advance.user.search.username=Username
 advance.user.search.name=Name
 advance.user.search.email=Email

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -731,16 +731,16 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         for (final User user : users) {
             final String username = JID.unescapeNode(user.getUsername());
 
-            final LinkedHashMap<String, Object> item = new  LinkedHashMap<String, Object>();
+            searchResults.addReportedField("jid", LocaleUtils.getLocalizedString("advance.user.search.jid", "search"), FormField.Type.jid_single );
+            searchResults.addReportedField("username", LocaleUtils.getLocalizedString("advance.user.search.username", "search"), FormField.Type.text_single );
+            searchResults.addReportedField("name", LocaleUtils.getLocalizedString("advance.user.search.name", "search"), FormField.Type.text_single );
+            searchResults.addReportedField("email", LocaleUtils.getLocalizedString("advance.user.search.email", "search"), FormField.Type.text_single );
+
+            final LinkedHashMap<String, Object> item = new  LinkedHashMap<>();
             item.put("jid", username + "@" + serverName);
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.username", "search",null, Locale.ENGLISH,false), username);
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.name", "search",null, Locale.ENGLISH,false),
-                    (user.isNameVisible() ? removeNull(user.getName()) : ""));
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.email", "search",null, Locale.ENGLISH,false),
-                    (user.isEmailVisible() ? removeNull(user.getEmail()) : ""));
+            item.put("username", username);
+            item.put("name", (user.isNameVisible() ? removeNull(user.getName()) : ""));
+            item.put("email", (user.isEmailVisible() ? removeNull(user.getEmail()) : ""));
 
             searchResults.addItemFields(item);
         }

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -17,20 +17,8 @@
 package org.jivesoftware.openfire.plugin;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
 
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
@@ -746,12 +734,12 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
             final LinkedHashMap<String, Object> item = new  LinkedHashMap<String, Object>();
             item.put("jid", username + "@" + serverName);
 
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.username", "search"), username);
+            item.put(LocaleUtils.getLocalizedString("advance.user.search.username", "search",null, Locale.ENGLISH,false), username);
 
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.name", "search"),
+            item.put(LocaleUtils.getLocalizedString("advance.user.search.name", "search",null, Locale.ENGLISH,false),
                     (user.isNameVisible() ? removeNull(user.getName()) : ""));
 
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.email", "search"),
+            item.put(LocaleUtils.getLocalizedString("advance.user.search.email", "search",null, Locale.ENGLISH,false),
                     (user.isEmailVisible() ? removeNull(user.getEmail()) : ""));
 
             searchResults.addItemFields(item);


### PR DESCRIPTION
This happens because propepries:advance.user.search.username, advance.user.search.name ,advance.user.search.email must use an English translation string or must not be translated.

If the Brazilian/Russian language was set in Openfire, then the search stopped working.
The Latvian language was not affected by this problem because it is not available in Openfire.