### PR TITLE
fixes #25: Compatibility with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,13 @@
 Search Plugin Changelog
 </h1>
 
+<p><b>1.7.5</b> -- (tbd)</p>
+<ul>
+    <li>Requires Openfire 4.4.0.</li>
+    <li>Minimum Java requirement: 11</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/25'>Issue #25</a>] - Fixed compatibility with Openfire 5.0.0.</li>
+</ul>
+
 <p><b>1.7.4</b> -- July 20, 2023</p>
 <ul>
     <li>Added Portuguese translations (by Miguel Veiga)</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,9 +6,9 @@
     <description>Provides support for Jabber Search (XEP-0055)</description>
     <author>Ryan Graham</author>
     <version>${project.version}</version>
-    <date>2023-07-20</date>
-    <minServerVersion>4.1.1</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2025-06-25</date>
+    <minServerVersion>4.4.0</minServerVersion>
+    <minJavaVersion>11</minJavaVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.4.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>search</artifactId>

--- a/src/web/search-props-edit-form.jsp
+++ b/src/web/search-props-edit-form.jsp
@@ -18,7 +18,7 @@
     boolean searchEnabled = ParamUtils.getBooleanParameter(request, "searchEnabled");
     boolean groupOnly = ParamUtils.getBooleanParameter(request, "groupOnly");
     
-    SearchPlugin plugin = (SearchPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("search");
+    SearchPlugin plugin = (SearchPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("Search").orElseThrow();
 
     // Handle a save
     Map<String,String> errors = new HashMap<>();


### PR DESCRIPTION
This removes usage of API that was dropped in Openfire 5.0.0, replacing it with API that was introduced in Openfire 4.4.0.

As a result, the plugin now requires at a minimum Openfire 4.4.0, and Java 11.