### PR TITLE
Release 1.7.5

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,7 +44,7 @@
 Search Plugin Changelog
 </h1>
 
-<p><b>1.7.5</b> -- (tbd)</p>
+<p><b>1.7.5</b> -- June 25, 2025</p>
 <ul>
     <li>Requires Openfire 4.4.0.</li>
     <li>Minimum Java requirement: 11</li>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>search</artifactId>
-    <version>1.7.5-SNAPSHOT</version>
+    <version>1.7.5</version>
     <name>Search</name>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>search</artifactId>
-    <version>1.7.5</version>
+    <version>1.7.6-SNAPSHOT</version>
     <name>Search</name>
 
     <repositories>


### PR DESCRIPTION
When we release this, we need to update Openfire, as it bundles this plugin. It needs to bundle the latest version of the plugin.