### PR TITLE
Fix search form lang

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 Search Plugin Changelog
 </h1>
 
+<p><b>1.7.6</b> -- Unreleased</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/19'>Issue #19</a>] - The search doesn't find anything if use a non-English localization</li>
+    <li>Refactoring</li>
+</ul>
+
 <p><b>1.7.5</b> -- June 25, 2025</p>
 <ul>
     <li>Requires Openfire 4.4.0.</li>

--- a/changelog.html
+++ b/changelog.html
@@ -44,9 +44,11 @@
 Search Plugin Changelog
 </h1>
 
-<p><b>1.7.6</b> -- Unreleased</p>
+<p><b>1.8.0</b> -- Sep 25, 2025</p>
 <ul>
-    <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/19'>Issue #19</a>] - The search doesn't find anything if use a non-English localization</li>
+    <li>Requires Openfire 5.0.0.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-search-plugin/issues/19'>Issue #19</a>] - Return search form in user's locale, fix search for non-English localization</li>
+    <li>Fix missing FORM_TYPE value for results</li>
     <li>Refactoring</li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,9 +7,8 @@
     <author>${project.developers[0].name}</author>
     <licenseType>apache</licenseType>
     <version>${project.version}</version>
-    <date>2025-06-25</date>
-    <minServerVersion>4.4.0</minServerVersion>
-    <minJavaVersion>11</minJavaVersion>
+    <date>2025-09-25</date>
+    <minServerVersion>5.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.4.0</version>
+        <version>5.0.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>search</artifactId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <name>Search</name>
     <description>Provides support for Jabber Search (XEP-0055)</description>
     <issueManagement>
@@ -43,11 +43,6 @@
             </snapshots>
         </repository>
     </repositories>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Use static build timestamp for reproducible builds -->
-        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
-    </properties>
     <build>
         <sourceDirectory>src/java</sourceDirectory>
         <plugins>
@@ -56,17 +51,8 @@
             </plugin>
             <!-- Compiles the Openfire Admin Console JSP pages. -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
-                <!-- Force the Openfire 4.2.x compatible version of JSP -->
-                <version>9.2.14.v20151106</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.igniterealtime.openfire</groupId>
-                        <artifactId>xmppserver</artifactId>
-                        <version>${openfire.version}</version>
-                    </dependency>
-                </dependencies>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/i18n/search_i18n.properties
+++ b/src/i18n/search_i18n.properties
@@ -12,6 +12,7 @@ advance.user.search.more_options=More Options
 advance.user.search.less_options=Less Options
 advance.user.search.users_found=Users Found
 advance.user.search.online=Online
+advance.user.search.jid=XMPP Address
 advance.user.search.username=Username
 advance.user.search.name=Name
 advance.user.search.email=Email

--- a/src/i18n/search_i18n_ru_RU.properties
+++ b/src/i18n/search_i18n_ru_RU.properties
@@ -9,6 +9,7 @@ advance.user.search.more_options=Больше опций
 advance.user.search.less_options=Меньше опций
 advance.user.search.users_found=Найдены пользователи
 advance.user.search.online=В сети
+advance.user.search.jid=XMPP-адрес
 advance.user.search.username=Имя пользователя
 advance.user.search.name=Имя
 advance.user.search.email=Электронная почта

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -99,7 +99,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
     private boolean groupOnly;
 
-    private static String serverName;
+    private String serverName;
 
     private TreeMap<String, String> fieldLookup = new TreeMap<>(CASE_INSENSITIVE_ORDER);
     private Map<String, String> reverseFieldLookup = new HashMap<String, String>();

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -722,7 +722,8 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         searchResults.addField("FORM_TYPE", null, FormField.Type.hidden)
             .addValue(NAMESPACE_JABBER_IQ_SEARCH);
 
-        searchResults.addReportedField("jid", "JID", FormField.Type.jid_single);
+        String fieldLabelJid = LocaleUtils.getLocalizedString("advance.user.search.jid", "search", null, preferredLocale, false);
+        searchResults.addReportedField("jid", fieldLabelJid, FormField.Type.jid_single);
         String fieldLabelEmail = LocaleUtils.getLocalizedString("advance.user.search.email", "search", null, preferredLocale, false);
         searchResults.addReportedField("email", fieldLabelEmail, FormField.Type.text_single);
 

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -727,7 +727,8 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
     private IQ replyDataFormResult(Collection<User> users, IQ packet) {
         final DataForm searchResults = new DataForm(DataForm.Type.result);
 
-        searchResults.addField("FORM_TYPE", null, FormField.Type.hidden);
+        searchResults.addField("FORM_TYPE", null, FormField.Type.hidden)
+            .addValue(NAMESPACE_JABBER_IQ_SEARCH);
 
         searchResults.addReportedField("jid", "JID", FormField.Type.jid_single);
 

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -745,14 +745,9 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
             final LinkedHashMap<String, Object> item = new  LinkedHashMap<String, Object>();
             item.put("jid", jid);
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.username", "search"), username);
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.name", "search"),
-                name);
-
-            item.put(LocaleUtils.getLocalizedString("advance.user.search.email", "search"),
-                email);
+            item.put("Username", username);
+            item.put("Name", name);
+            item.put("Email", email);
 
             searchResults.addItemFields(item);
         }

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -604,7 +604,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
     private Set<User> performSearch(Element incomingForm, int startIndex, int max) {
         Set<User> users = new HashSet<User>();
 
-        Hashtable<String, String> searchList = extractSearchQuery(incomingForm);
+        Map<String, String> searchList = extractSearchQuery(incomingForm);
 
         for (Entry<String, String> entry : searchList.entrySet()) {
             String field = entry.getKey();
@@ -654,7 +654,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @return The search query for a particular user search request.
      */
     @SuppressWarnings("unchecked")
-    private Hashtable<String, String> extractSearchQuery(Element incomingForm) {
+    private Map<String, String> extractSearchQuery(Element incomingForm) {
         if (incomingForm.element(QName.get("x", "jabber:x:data")) != null) {
             // forward the request.
             return extractExtendedSearchQuery(incomingForm);
@@ -689,7 +689,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @see #extractSearchQuery(Element)
      */
     @SuppressWarnings("unchecked")
-    private Hashtable<String, String> extractExtendedSearchQuery(Element incomingForm) {
+    private Map<String, String> extractExtendedSearchQuery(Element incomingForm) {
         final Element dataform = incomingForm.element(QName.get("x", "jabber:x:data"));
 
         Hashtable<String, String> searchList = new Hashtable<String, String>();

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -608,7 +608,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         for (Entry<String, String> entry : searchList.entrySet()) {
             String field = entry.getKey();
             String query = entry.getValue();
-            if (userManager != null && query.length() > 0 && !query.equals(NAMESPACE_JABBER_IQ_SEARCH)) {
+            if (!query.isEmpty() && !query.equals(NAMESPACE_JABBER_IQ_SEARCH)) {
                 if (max >= 0) {
                     users.addAll(userManager.findUsers(new HashSet<String>(Arrays.asList(field)), query, startIndex, max));
                 } else {

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -605,28 +605,19 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         Set<User> users = new HashSet<User>();
 
         Map<String, String> searchList = extractSearchQuery(incomingForm);
-
         for (Entry<String, String> entry : searchList.entrySet()) {
             String field = entry.getKey();
             String query = entry.getValue();
-
-            Collection<User> foundUsers = new ArrayList<User>();
-
             if (userManager != null && query.length() > 0 && !query.equals(NAMESPACE_JABBER_IQ_SEARCH)) {
                 if (max >= 0) {
-                    foundUsers.addAll(userManager.findUsers(new HashSet<String>(Arrays.asList(field)), query, startIndex, max));
+                    users.addAll(userManager.findUsers(new HashSet<String>(Arrays.asList(field)), query, startIndex, max));
                 } else {
-                    foundUsers.addAll(userManager.findUsers(new HashSet<String>(Arrays.asList(field)), query));
-                }
-            }
-
-            // occasionally a null User is returned so filter them out
-            for (User user : foundUsers) {
-                if (user != null) {
-                    users.add(user);
+                    users.addAll(userManager.findUsers(new HashSet<String>(Arrays.asList(field)), query));
                 }
             }
         }
+        // occasionally a null User is returned so filter them out
+        users.remove(null);
         return users;
     }
 

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -143,6 +143,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#getName()
      */
+    @Override
     public String getName() {
         return PluginMetadataHelper.getName(this);
     }
@@ -152,6 +153,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#getDescription()
      */
+    @Override
     public String getDescription() {
         return PluginMetadataHelper.getDescription(this);
     }
@@ -161,6 +163,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.jivesoftware.openfire.container.Plugin#initializePlugin(org.jivesoftware.openfire.container.PluginManager, java.io.File)
      */
+    @Override
     public void initializePlugin(PluginManager manager, File pluginDirectory) {
         componentManager = ComponentManagerFactory.getComponentManager();
         try {
@@ -176,6 +179,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#initialize(org.xmpp.packet.JID, org.xmpp.component.ComponentManager)
      */
+    @Override
     public void initialize(JID jid, ComponentManager componentManager) {
     }
 
@@ -184,6 +188,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#start()
      */
+    @Override
     public void start() {
     }
 
@@ -192,6 +197,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.jivesoftware.openfire.container.Plugin#destroyPlugin()
      */
+    @Override
     public void destroyPlugin() {
         PropertyEventDispatcher.removeListener(this);
         try {
@@ -215,6 +221,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#shutdown()
      */
+    @Override
     public void shutdown() {
     }
 
@@ -223,6 +230,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @see org.xmpp.component.Component#processPacket(org.xmpp.packet.Packet)
      */
+    @Override
     public void processPacket(Packet p) {
         if (!(p instanceof IQ)) {
             return;

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -301,7 +301,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
                 replyPacket.setChildElement("query", IQDiscoItemsHandler.NAMESPACE_DISCO_ITEMS);
                 break;
             default:
-                // don't known what to do with this.
+                // don't know what to do with this.
                 replyPacket = IQ.createResultIQ(iq);
                 replyPacket.setError(Condition.feature_not_implemented);
                 break;
@@ -380,7 +380,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @param packet
      *            An IQ stanza of type 'get'
-     * @return A result IQ stanza that contains the possbile search fields.
+     * @return A result IQ stanza that contains the possible search fields.
      */
     private IQ processGetPacket(IQ packet) {
         if (!packet.getType().equals(IQ.Type.get)) {
@@ -428,7 +428,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * 
      * @param packet
      *            An IQ stanza of type 'get'
-     * @return A result IQ stanza that contains the possbile search fields.
+     * @return A result IQ stanza that contains the possible search fields.
      */
     private IQ processSetPacket(IQ packet) {
         if (!packet.getType().equals(IQ.Type.set)) {
@@ -448,22 +448,14 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
         final Element incomingForm = packet.getChildElement();
         final boolean isDataFormQuery = (incomingForm.element(QName.get("x", "jabber:x:data")) != null);
-
+        // XEP-0059 Result Set Management
         final Element rsmElement = incomingForm.element(QName.get("set", ResultSet.NAMESPACE_RESULT_SET_MANAGEMENT));
 
         if (rsmElement != null) {
-            final Element maxElement = rsmElement.element("max");
             final Element startIndexElement = rsmElement.element("index");
-
-            int startIndex = 0;
-            if (startIndexElement != null) {
-                startIndex = Integer.parseInt(startIndexElement.getTextTrim());
-            }
-
-            int max = -1;
-            if (maxElement != null) {
-                max = Integer.parseInt(maxElement.getTextTrim());
-            }
+            int startIndex = startIndexElement != null ? Integer.parseInt(startIndexElement.getTextTrim()) : 0;
+            final Element maxElement = rsmElement.element("max");
+            int max = maxElement != null ? Integer.parseInt(maxElement.getTextTrim()) : -1;
 
             final Set<User> searchResults = performSearch(incomingForm, startIndex, max);
 
@@ -549,14 +541,13 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * <ul>
      * <li>if the IQ stanza is of type 'set';</li>
      * <li>if a child element identified by the jabber:iq:search namespace is supplied;</li>
-     * <li>if the stanza child element is has valid children itself.</li>
+     * <li>if the stanza child element has a valid children itself.</li>
      * </ul>
      * 
      * @param iq
      *            The IQ object that should include a jabber:iq:search request.
      * @return ''true'' if the supplied IQ stanza is a spec compliant search request, ''false'' otherwise.
      */
-    @SuppressWarnings("unchecked")
     public static boolean isValidSearchRequest(IQ iq) {
 
         if (iq == null) {
@@ -637,10 +628,10 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
     }
 
     /**
-     * This utilty method extracts the search query from the request. A query is defined as a set of key->value pairs, where the key denotes
+     * This utility method extracts the search query from the request. A query is defined as a set of key->value pairs, where the key denotes
      * a search field, and the value contains the value that was filled out by the user for that field.
      * 
-     * The query can be specified in one of two ways. The first way is a query is formed is by filling out any of the the standard search
+     * The query can be specified in one of two ways. The first way is a query is formed is by filling out any of the standard search
      * fields. The other search method makes use of extended data forms. Search queries that are supplied to this
      * {@link #extractSearchQuery(Element)} that make use of this last method get forwarded to {@link #extractExtendedSearchQuery(Element)}.
      * 
@@ -648,7 +639,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      *            The form from which to extract the query
      * @return The search query for a particular user search request.
      */
-    @SuppressWarnings("unchecked")
     private Map<String, String> extractSearchQuery(Element incomingForm) {
         if (incomingForm.element(QName.get("x", "jabber:x:data")) != null) {
             // forward the request.
@@ -664,7 +654,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
             String name = element.getName();
 
             if (fieldLookup.containsKey(name)) {
-                // make best effort to map the fields submitted by
+                // make the best effort to map the fields submitted by
                 // the client to those that Openfire can search
                 reverseFieldLookup.put(fieldLookup.get(name), name);
                 searchList.put(fieldLookup.get(name), element.getText());
@@ -683,7 +673,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @return The search query for a particular user search request.
      * @see #extractSearchQuery(Element)
      */
-    @SuppressWarnings("unchecked")
     private Map<String, String> extractExtendedSearchQuery(Element incomingForm) {
         final Element dataform = incomingForm.element(QName.get("x", "jabber:x:data"));
 
@@ -816,7 +805,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
     }
 
     /**
-     * Sets the service name of this component, which is "search" by default. If the name is different than the existing name the plugin
+     * Sets the service name of this component, which is "search" by default. If the name is different from the existing name the plugin
      * will remove itself from the ComponentManager and then add itself back using the new name.
      * 
      * @param name
@@ -1007,7 +996,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
     /**
      * Returns the collection of field names that can be used to search for a user. Typical fields are username, name, and email. These
-     * values can be used to contruct a data form.
+     * values can be used to construct a data form.
      * 
      * @return the collection of field names that can be used to search.
      */

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -732,23 +732,27 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         searchResults.addReportedField("jid", "JID", FormField.Type.jid_single);
 
         for (final String fieldName : getFilteredSearchFields()) {
+            String fieldLabel = LocaleUtils.getLocalizedString("advance.user.search." + fieldName.toLowerCase(), "search");
             searchResults.addReportedField(fieldName,
-                    LocaleUtils.getLocalizedString("advance.user.search." + fieldName.toLowerCase(), "search"), FormField.Type.text_single);
+                fieldLabel, FormField.Type.text_single);
         }
 
         for (final User user : users) {
             final String username = JID.unescapeNode(user.getUsername());
+            String jid = username + "@" + serverName;
+            String name = user.isNameVisible() ? removeNull(user.getName()) : "";
+            String email = user.isEmailVisible() ? removeNull(user.getEmail()) : "";
 
             final LinkedHashMap<String, Object> item = new  LinkedHashMap<String, Object>();
-            item.put("jid", username + "@" + serverName);
+            item.put("jid", jid);
 
             item.put(LocaleUtils.getLocalizedString("advance.user.search.username", "search"), username);
 
             item.put(LocaleUtils.getLocalizedString("advance.user.search.name", "search"),
-                    (user.isNameVisible() ? removeNull(user.getName()) : ""));
+                name);
 
             item.put(LocaleUtils.getLocalizedString("advance.user.search.email", "search"),
-                    (user.isEmailVisible() ? removeNull(user.getEmail()) : ""));
+                email);
 
             searchResults.addItemFields(item);
         }
@@ -776,7 +780,10 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         for (User user : users) {
             Element item = replyQuery.addElement("item");
             String username = JID.unescapeNode(user.getUsername());
-            item.addAttribute("jid", username + "@" + serverName);
+            String jid = username + "@" + serverName;
+            String name = user.isNameVisible() ? removeNull(user.getName()) : "";
+            String email = user.isEmailVisible() ? removeNull(user.getEmail()) : "";
+            item.addAttribute("jid", jid);
 
             // return to the client the same fields that were submitted
             for (String field : reverseFieldLookup.keySet()) {
@@ -788,12 +795,12 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
                     }
                     case "Name": {
                         Element element = item.addElement(reverseFieldLookup.get(field));
-                        element.addText(user.isNameVisible() ? removeNull(user.getName()) : "");
+                        element.addText(name);
                         break;
                     }
                     case "Email": {
                         Element element = item.addElement(reverseFieldLookup.get(field));
-                        element.addText(user.isEmailVisible() ? removeNull(user.getEmail()) : "");
+                        element.addText(email);
                         break;
                     }
                 }
@@ -848,7 +855,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
     /**
      * Returns the collection of searchable field names that does not include the fields listed in the EXCLUDEDFIELDS property list.
      * 
-     * @return collection of searchable field names.
+     * @return collection of searchable field names e.g. "Username", "Name", "Email".
      */
     public Collection<String> getFilteredSearchFields() {
         Collection<String> searchFields;

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -92,7 +92,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
     private UserManager userManager;
     private ComponentManager componentManager;
-    private PluginManager pluginManager;
 
     private String serviceName;
     private boolean serviceEnabled;
@@ -163,8 +162,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @see org.jivesoftware.openfire.container.Plugin#initializePlugin(org.jivesoftware.openfire.container.PluginManager, java.io.File)
      */
     public void initializePlugin(PluginManager manager, File pluginDirectory) {
-        pluginManager = manager;
-
         componentManager = ComponentManagerFactory.getComponentManager();
         try {
             componentManager.addComponent(serviceName, this);
@@ -197,7 +194,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      */
     public void destroyPlugin() {
         PropertyEventDispatcher.removeListener(this);
-        pluginManager = null;
         try {
             componentManager.removeComponent(serviceName);
             componentManager = null;

--- a/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -124,7 +124,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         excludedFields = StringUtils.stringToCollection(JiveGlobals.getProperty(EXCLUDEDFIELDS, ""));
         groupOnly = JiveGlobals.getBooleanProperty(GROUPONLY);
 
-        serverName = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
         userManager = UserManager.getInstance();
 
         // Some clients, such as Miranda, are hard-coded to search specific fields,
@@ -211,7 +210,6 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         serviceName = null;
         userManager = null;
         excludedFields = null;
-        serverName = null;
         fieldLookup = null;
         reverseFieldLookup = null;
     }
@@ -735,12 +733,12 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
 
         for (final User user : users) {
             final String username = JID.unescapeNode(user.getUsername());
-            String jid = username + "@" + serverName;
+            JID jid = XMPPServer.getInstance().createJID(username, null);
             String name = user.isNameVisible() ? removeNull(user.getName()) : "";
             String email = user.isEmailVisible() ? removeNull(user.getEmail()) : "";
 
             final LinkedHashMap<String, Object> item = new  LinkedHashMap<String, Object>();
-            item.put("jid", jid);
+            item.put("jid", jid.toString());
             item.put("Username", username);
             item.put("Name", name);
             item.put("Email", email);
@@ -771,10 +769,10 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
         for (User user : users) {
             Element item = replyQuery.addElement("item");
             String username = JID.unescapeNode(user.getUsername());
-            String jid = username + "@" + serverName;
+            JID jid = XMPPServer.getInstance().createJID(username, null);
             String name = user.isNameVisible() ? removeNull(user.getName()) : "";
             String email = user.isEmailVisible() ? removeNull(user.getEmail()) : "";
-            item.addAttribute("jid", jid);
+            item.addAttribute("jid", jid.toString());
 
             // return to the client the same fields that were submitted
             for (String field : reverseFieldLookup.keySet()) {


### PR DESCRIPTION
Based #31 so see only last commits.

The final fix for the #19.
In order to show the search form in user locale we need to call the `SessionManager.getInstance().getLocaleForSession` but it's not available in the old Openfire so we also need to upgrade it.
So it will need for a separate release.

